### PR TITLE
include the `response` in `get` calls

### DIFF
--- a/clearbit/tests.py
+++ b/clearbit/tests.py
@@ -91,3 +91,7 @@ class TestPersonCompany(unittest.TestCase):
     def test_endpoint(self, requests):
         PersonCompany.find(email='user@example.com')
         requests.get.assert_called_with('https://person.clearbit.com/v1/combined/email/user@example.com', params={}, auth=(None, ''))
+
+        
+if __name__ == '__main__':
+        unittest.main()


### PR DESCRIPTION
after calling `get` calls, e.g. `clearbit.Company.find(domain="stripe.com")`, this PR includes the `response` as a key in the returned dict.

e.g.

```python
stripe = clearbit.Company.find(domain='stripe.com')
print(stripe['response']) # <HTTP Response status_code=200 ...>
```

This allows for explicit HTTP code handling (as opposed to checking for, e.g. `{ 'pending': True }`), logging what endpoint URL was hit, etc.


concerns: name-collisions with Clearbit API JSON return keys. But I suspect clearbit entities won't have keys named `response`.

