### PR TITLE
added eqivalent method to dict get method

### DIFF
--- a/clearbit/resource.py
+++ b/clearbit/resource.py
@@ -76,3 +76,13 @@ class Resource(dict):
         response.raise_for_status()
 
         return response
+
+    def get_field(self, field, default):
+        return self.__dict__().get(field, default)
+
+    def __dict__(self):
+        resource_dict = {}
+        for key, value in self.items():
+            resource_dict[key] = value
+        return resource_dict
+    


### PR DESCRIPTION
- the dict get method was override by another get method (similar to GET request). Hence, I added the get_field method.
- also added __dict__() method which converts the object to a regular dict