### PR TITLE
Add python 3.{4,5,6} classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,9 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ])


### PR DESCRIPTION
Verified compatibility with 3.6.

I Would expect this should be fine in .4 and .5 too.